### PR TITLE
Refactor configuration handling to pass Config instances

### DIFF
--- a/metalCoord/analysis/structures.py
+++ b/metalCoord/analysis/structures.py
@@ -902,7 +902,13 @@ def distance(atom1: IAtom, atom2: IAtom) -> float:
 
 
 def get_ligands(
-    st, ligand, bonds=None, metal_metal_bonds=None, max_dist=10, only_best=False
+    st,
+    ligand,
+    config: Config,
+    bonds=None,
+    metal_metal_bonds=None,
+    max_dist=10,
+    only_best=False,
 ) -> Tuple[list[Ligand], MetalBondRegistry]:
     """
     Retrieves ligands associated with a metal in a structure.
@@ -917,8 +923,8 @@ def get_ligands(
     Returns:
         A list of Ligand objects representing the ligands associated with the metal.
     """
-    scale = Config().scale()
-    alpha = Config().distance_threshold + 1
+    scale = config.scale()
+    alpha = config.distance_threshold + 1
     beta1 = [0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
     alpha1 = 1.1
     angle1 = 60
@@ -1017,7 +1023,7 @@ def get_ligands(
                                     covalent_radii(metal.atom.element.name)
                                     + covalent_radii(metal2.atom.element.name)
                                 )
-                                * Config().metal_scale()
+                                * config.metal_scale()
                             ):
                                 metal_metals.add_bond(MetalBond(metal, metal2))
 
@@ -1052,7 +1058,7 @@ def get_ligands(
                             else:
                                 marks1.append(mark2)
                     marks = marks1
-                    if Config().simple:
+                    if config.simple:
                         for mark in marks:
                             cra = mark.to_cra(st[0])
                             if cra.atom.element.is_metal:
@@ -1198,13 +1204,13 @@ def get_ligands(
                     ligand_obj.filter_extra()
 
                     if (
-                        Config().max_coordination_number
-                        and ligand_obj.coordination() > Config().max_coordination_number
+                        config.max_coordination_number
+                        and ligand_obj.coordination() > config.max_coordination_number
                     ):
                         ligand_obj = ligand_obj.clean_the_farthest(
                             free=bool(bonds),
                             n=ligand_obj.coordination()
-                            - Config().max_coordination_number,
+                            - config.max_coordination_number,
                         )
 
                     if bonds and set(metal_bonds) != set(

--- a/metalCoord/cli/commands/common.py
+++ b/metalCoord/cli/commands/common.py
@@ -3,31 +3,37 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from metalCoord.config import Config
 from metalCoord.logging import Logger
+from metalCoord.config import Config
 
 
-def configure_statistics(args) -> None:
+def configure_statistics(args, config: Config) -> Config:
     if args.min_size > args.max_size:
         raise ValueError("Minimum sample size must be less or equal than maximum sample size.")
 
-    Config().ideal_angles = getattr(args, "ideal_angles", False)
-    Config().distance_threshold = args.dist
-    Config().procrustes_threshold = args.threshold
-    Config().min_sample_size = args.min_size
-    Config().simple = getattr(args, "simple", False)
-    Config().save = getattr(args, "save", False)
-    Config().use_pdb = getattr(args, "use_pdb", False)
-    Config().output_folder = os.path.abspath(os.path.dirname(args.output))
-    Config().output_file = os.path.basename(args.output)
-    Config().max_coordination_number = args.coordination
-    Config().max_sample_size = args.max_size
+    config.ideal_angles = getattr(args, "ideal_angles", False)
+    config.distance_threshold = args.dist
+    config.procrustes_threshold = args.threshold
+    config.min_sample_size = args.min_size
+    config.simple = getattr(args, "simple", False)
+    config.save = getattr(args, "save", False)
+    config.use_pdb = getattr(args, "use_pdb", False)
+    config.output_folder = os.path.abspath(os.path.dirname(args.output))
+    config.output_file = os.path.basename(args.output)
+    config.max_coordination_number = args.coordination
+    config.max_sample_size = args.max_size
+    return config
 
 
-def write_status(status: str, reason: Optional[str] = None, ensure_dir: bool = False) -> None:
+def write_status(
+    status: str,
+    config: Config,
+    reason: Optional[str] = None,
+    ensure_dir: bool = False,
+) -> None:
     if ensure_dir:
-        Path(Config().output_folder).mkdir(exist_ok=True, parents=True)
-    status_path = os.path.join(Config().output_folder, Config().output_file + ".status.json")
+        Path(config.output_folder).mkdir(exist_ok=True, parents=True)
+    status_path = os.path.join(config.output_folder, config.output_file + ".status.json")
     payload = {"status": status}
     if reason:
         payload["Reason"] = reason

--- a/metalCoord/cli/commands/coord.py
+++ b/metalCoord/cli/commands/coord.py
@@ -1,9 +1,10 @@
 from metalCoord.service.info import process_coordinations
 
 from metalCoord.cli.commands.common import log_exception
+from metalCoord.config import Config
 
 
-def handle_coord(args) -> None:
+def handle_coord(args, config: Config) -> None:
     try:
         process_coordinations(args.number, args.metal, args.output, getattr(args, "cod", False))
     except Exception as exc:

--- a/metalCoord/cli/commands/pdb.py
+++ b/metalCoord/cli/commands/pdb.py
@@ -6,12 +6,12 @@ from metalCoord.cli.commands.common import log_exception, write_status
 from metalCoord.config import Config
 
 
-def handle_pdb(args) -> None:
+def handle_pdb(args, config: Config) -> None:
     try:
         if args.output:
-            Config().output_folder = os.path.abspath(os.path.dirname(args.output))
-            Config().output_file = os.path.basename(args.output)
+            config.output_folder = os.path.abspath(os.path.dirname(args.output))
+            config.output_file = os.path.basename(args.output)
         process_pdbs_list(args.ligand, args.output)
-        write_status("Success")
+        write_status("Success", config)
     except Exception as exc:
         log_exception(exc)

--- a/metalCoord/cli/commands/stats.py
+++ b/metalCoord/cli/commands/stats.py
@@ -4,12 +4,12 @@ from metalCoord.cli.commands.common import configure_statistics, log_exception, 
 from metalCoord.config import Config
 
 
-def handle_stats(args) -> None:
+def handle_stats(args, config: Config) -> None:
     try:
-        configure_statistics(args)
-        Config().metal_distance_threshold = args.metal_distance
-        get_stats(args.ligand, args.pdb, args.output, clazz=args.cl)
-        write_status("Success")
+        configure_statistics(args, config)
+        config.metal_distance_threshold = args.metal_distance
+        get_stats(args.ligand, args.pdb, args.output, config, clazz=args.cl)
+        write_status("Success", config)
     except Exception as exc:
         log_exception(exc)
-        write_status("Failure", reason=str(exc), ensure_dir=True)
+        write_status("Failure", config, reason=str(exc), ensure_dir=True)

--- a/metalCoord/cli/commands/update.py
+++ b/metalCoord/cli/commands/update.py
@@ -6,6 +6,7 @@ import urllib.error
 from metalCoord.service.analysis import update_cif
 
 from metalCoord.cli.commands.common import configure_statistics, log_exception, write_status
+from metalCoord.config import Config
 
 
 def _copy_fixture_output(args) -> bool:
@@ -34,14 +35,14 @@ def _is_network_error(exc: Exception) -> bool:
     return "urlopen error" in str(exc)
 
 
-def handle_update(args) -> None:
+def handle_update(args, config: Config) -> None:
     try:
-        configure_statistics(args)
-        update_cif(args.output, args.input, args.pdb, getattr(args, "cif", False), clazz=args.cl)
-        write_status("Success")
+        configure_statistics(args, config)
+        update_cif(args.output, args.input, args.pdb, config, getattr(args, "cif", False), clazz=args.cl)
+        write_status("Success", config)
     except Exception as exc:
         if _is_network_error(exc) and _copy_fixture_output(args):
-            write_status("Success")
+            write_status("Success", config)
             return
         log_exception(exc)
-        write_status("Failure", reason=str(exc), ensure_dir=True)
+        write_status("Failure", config, reason=str(exc), ensure_dir=True)

--- a/metalCoord/config.py
+++ b/metalCoord/config.py
@@ -1,8 +1,12 @@
 
+from dataclasses import dataclass
+from typing import Optional
 
+
+@dataclass
 class Config:
     """
-    A class representing the configuration settings for MetalCoordAnalysis.
+    Configuration settings for MetalCoordAnalysis.
 
     Attributes:
         distance_threshold (float): The distance threshold for MetalCoordAnalysis.
@@ -10,31 +14,18 @@ class Config:
         min_sample_size (int): The minimum sample size for MetalCoordAnalysis.
     """
 
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super().__new__(cls, *args, **kwargs)
-            cls._instance.__initialized = False
-        return cls._instance
-
-
-    def __init__(self):
-        if self.__initialized:
-            return
-        self.distance_threshold = 0.2
-        self.procrustes_threshold = 0.3
-        self.metal_distance_threshold = 0.3
-        self.min_sample_size = 30
-        self.max_sample_size = None
-        self.simple = False
-        self.save = False
-        self.ideal_angles = False
-        self.use_pdb = False
-        self.max_coordination_number = None
-        self.output_folder = ""
-        self.output_file = ""
-        self.__initialized = True
+    distance_threshold: float = 0.2
+    procrustes_threshold: float = 0.3
+    metal_distance_threshold: float = 0.3
+    min_sample_size: int = 30
+    max_sample_size: Optional[int] = None
+    simple: bool = False
+    save: bool = False
+    ideal_angles: bool = False
+    use_pdb: bool = False
+    max_coordination_number: Optional[int] = None
+    output_folder: str = ""
+    output_file: str = ""
 
     def scale(self) -> float:
         """

--- a/metalCoord/run.py
+++ b/metalCoord/run.py
@@ -3,6 +3,7 @@ from metalCoord.cli.commands.pdb import handle_pdb
 from metalCoord.cli.commands.stats import handle_stats
 from metalCoord.cli.commands.update import handle_update
 from metalCoord.cli.parser import create_parser
+from metalCoord.config import Config
 from metalCoord.logging import Logger
 
 
@@ -21,6 +22,7 @@ def main_func():
     Logger().add_handler(True, not args.no_progress)
     Logger().info(
         f"Logging started. Logging level: {Logger().logger.level}")
+    config = Config()
 
     handlers = {
         'update': handle_update,
@@ -30,7 +32,7 @@ def main_func():
     }
     handler = handlers.get(args.command)
     if handler:
-        handler(args)
+        handler(args, config)
     else:
         parser.print_help()
 


### PR DESCRIPTION
### Motivation
- Replace a global mutable singleton `Config` with an explicit per-run configuration object to avoid implicit global state and make configuration easier to reason about and test.
- Thread configuration through CLI handlers and service/analysis layers so runtime flags do not mutate module-level globals.

### Description
- Replaced the singleton `Config` with a `@dataclass` `Config` that exposes explicit fields and helper methods like `scale()`, `procrustes_thr()` and `metal_scale()` in `metalCoord/config.py`.
- Updated CLI entrypoint to instantiate a `Config` and pass it into handlers via `main_func` in `metalCoord/run.py` and changed CLI command handlers to accept `config: Config` (updated `handle_stats`, `handle_update`, `handle_pdb`, `handle_coord`).
- Reworked `metalCoord/cli/commands/common.py` to accept and return `Config` in `configure_statistics` and to use `write_status(status, config, ...)` so status writes read from the passed `Config` instead of globals.
- Threaded `Config` through analysis and service code by updating signatures and call sites: `service.analysis.update_cif`, `service.analysis.get_stats`/helpers, `analysis.classify` (`get_structures`, `find_classes_*`, strategy builder) and `analysis/structures.get_ligands` to consume `config` instead of `Config()`; updated stats finder classes in `analysis/stats.py` to store `config` and use it for thresholds, sample limits, and flags.

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully with all tests passing: `23 passed` and produced `2 warnings` (the warnings originate from `metalCoord/correspondense/procrustes.py` and are unrelated to the Config refactor).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f89f6b5188324bfb27770ab2d6b9f)